### PR TITLE
NPE when call AP TypeElementImpl.getEnclosedElements()

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -389,6 +389,9 @@ public void setAnnotations(AnnotationBinding[] annotations) {
 	this.declaringClass.storeAnnotations(this, annotations);
 }
 public FieldDeclaration sourceField() {
+	//	AspectJ Extension
+	if(this.declaringClass instanceof BinaryTypeBinding) return null;
+	//	End AspectJ Extension
 	SourceTypeBinding sourceType;
 	try {
 		sourceType = (SourceTypeBinding) this.declaringClass;

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1223,6 +1223,9 @@ public final char[] signature(ClassFile classFile) {
 public final int sourceEnd() {
 	AbstractMethodDeclaration method = sourceMethod();
 	if (method == null) {
+		//	AspectJ Extension
+		if (this.declaringClass instanceof BinaryTypeBinding) return 0;
+		//	End AspectJ Extension
 		if (this.declaringClass instanceof SourceTypeBinding)
 			return ((SourceTypeBinding) this.declaringClass).sourceEnd();
 		return 0;
@@ -1266,6 +1269,9 @@ public LambdaExpression sourceLambda() {
 public final int sourceStart() {
 	AbstractMethodDeclaration method = sourceMethod();
 	if (method == null) {
+        //	AspectJ Extension
+		if (declaringClass instanceof BinaryTypeBinding) return 0;
+        //	End AspectJ Extension
 		if (this.declaringClass instanceof SourceTypeBinding)
 			return ((SourceTypeBinding) this.declaringClass).sourceStart();
 		return 0;


### PR DESCRIPTION
Example stacktrace using a QuerydslProcessor:

[ant:iajc] java.lang.NullPointerException         
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding.sourceStart(SourceTypeBinding.java:2454)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.lookup.MethodBinding.sourceStart(MethodBinding.java:1267)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl$SourceLocationComparator.determineSourceStart(TypeElementImpl.java:99)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl$SourceLocationComparator.getSourceStart(TypeElementImpl.java:72)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl$SourceLocationComparator.compare(TypeElementImpl.java:65)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl$SourceLocationComparator.compare(TypeElementImpl.java:1)
[ant:iajc]      at java.util.TimSort.countRunAndMakeAscending(TimSort.java:351)
[ant:iajc]      at java.util.TimSort.sort(TimSort.java:216)
[ant:iajc]      at java.util.Arrays.sort(Arrays.java:1435)
[ant:iajc]      at java.util.Collections.sort(Collections.java:230)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl.getEnclosedElements(TypeElementImpl.java:167)
[ant:iajc]      at com.mysema.query.apt.AbstractQuerydslProcessor.collectElements(AbstractQuerydslProcessor.java:249)
[ant:iajc]      at com.mysema.query.apt.AbstractQuerydslProcessor.processAnnotations(AbstractQuerydslProcessor.java:110)
[ant:iajc]      at com.mysema.query.apt.AbstractQuerydslProcessor.process(AbstractQuerydslProcessor.java:97)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:140)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:122)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManager.java:160)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:844)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:439)
[ant:iajc]      at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:420)
[ant:iajc]      at org.aspectj.ajdt.internal.core.builder.AjBuildManager.performCompilation(AjBuildManager.java:1036)
[ant:iajc]      at org.aspectj.ajdt.internal.core.builder.AjBuildManager.performBuild(AjBuildManager.java:272)
[ant:iajc]      at org.aspectj.ajdt.internal.core.builder.AjBuildManager.batchBuild(AjBuildManager.java:185)
[ant:iajc]      at org.aspectj.ajdt.ajc.AjdtCommand.doCommand(AjdtCommand.java:112)
[ant:iajc]      at org.aspectj.ajdt.ajc.AjdtCommand.runCommand(AjdtCommand.java:60)
[ant:iajc]      at org.aspectj.tools.ajc.Main.run(Main.java:371)
[ant:iajc]      at org.aspectj.tools.ajc.Main.runMain(Main.java:248)
[ant:iajc]      at org.aspectj.tools.ajc.Main.main(Main.java:84)

Rather, the main problem in the architecture of my solution looks like quick fix.